### PR TITLE
server: quick wins for stability

### DIFF
--- a/server/block.go
+++ b/server/block.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/labstack/gommon/log"
-	"github.com/syleron/426c/common/models"
-	"github.com/syleron/426c/common/packet"
-	"github.com/syleron/426c/common/utils"
-	"time"
+    "github.com/labstack/gommon/log"
+    "github.com/syleron/426c/common/models"
+    "github.com/syleron/426c/common/packet"
+    "github.com/syleron/426c/common/utils"
+    "time"
 )
 
 var (
@@ -31,10 +31,15 @@ func blockCalcCost() int {
 	return 1//TCSCount / n
 }
 
-func blockDistribute(clients map[string]*Client) {
+func blockDistribute(s *Server) {
 	for _ = range time.Tick(10 * time.Minute) {
 		log.Debug("Issuing blocks..")
-		for _, c := range clients {
+        // Take a snapshot of clients under read lock
+        s.mu.RLock()
+        clients := make([]*Client, 0, len(s.clients))
+        for _, c := range s.clients { clients = append(clients, c) }
+        s.mu.RUnlock()
+        for _, c := range clients {
 			// Increase user blocks by pre-configured amount
 			blocks, err := dbUserBlockCredit(c.Username, 5)
 			if err != nil {

--- a/server/database.go
+++ b/server/database.go
@@ -36,7 +36,7 @@ func dbUserBlockDebit(username string, total int) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if (user.Blocks - total) <= 0 {
+    if (user.Blocks - total) < 0 {
 		return user.Blocks, errors.New("insufficient blocks")
 	} else {
 		user.Blocks -= total

--- a/server/queue.go
+++ b/server/queue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/syleron/426c/common/utils"
 	"strconv"
 	"sync"
+	"time"
 )
 
 type Queue struct {
@@ -29,7 +30,7 @@ func newQueue(s *Server) *Queue {
 		server: s,
 	}
 	// start the queue in a go routine
-	go scheduler(q.process, 1000)
+    go scheduler(q.process, time.Second)
 	// return our queue
 	return q
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -6,7 +6,7 @@ import "time"
 Function to schedule the execution every x time as time.Duration.
 */
 func scheduler(method func() bool, delay time.Duration) {
-	for _ = range time.Tick(delay) {
+    for _ = range time.Tick(delay) {
 		end := method()
 		if end {
 			break


### PR DESCRIPTION
## Summary
- Guarded `Server.clients` with `sync.RWMutex` and added safe accessors; fixed data races across accept loop, message send, and block distributor.
- Early-return on initial read error; corrected error logging on accept.
- `authCheck` now returns bool; enforced early-return at `CMD_USER` and `CMD_MSGTO` call sites.
- Fixed scheduler interval to `time.Second` for queue processing.
- Adjusted debit logic to allow exact-cost sends (`< 0` instead of `<= 0`).
- Registration now responds with success/failure via `SVR_REGISTER`.
- Block distribution now snapshots clients under lock to avoid concurrent map access.

## Rationale
These are low-risk fixes that address correctness, crashers, and user feedback without altering the public protocol.

## Test plan
- Build `go build ./server`.
- Manual: register, login, send messages between two clients; verify:
  - Sending works when recipient is online; sender receives `SVR_MSGTO` with blocks.
  - When recipient is offline, sender gets failure and server does not panic.
  - Registration returns a response.
- Run multiple concurrent logins to the same user; ensure previous session is closed without data races.
- Let server run for >10 minutes; verify block distributor logs increments without panics.